### PR TITLE
Add proper error handling to several functions

### DIFF
--- a/lib/dentaku/ast/arithmetic.rb
+++ b/lib/dentaku/ast/arithmetic.rb
@@ -31,7 +31,12 @@ module Dentaku
       def value(context = {})
         l = cast(left.value(context))
         r = cast(right.value(context))
-        l.public_send(operator, r)
+        begin
+          l.public_send(operator, r)
+        rescue ::TypeError => e
+          # Right cannot be converted to a suitable type for left. e.g. [] + 1
+          raise Dentaku::ArgumentError.for(:incompatible_type, value: r, for: l.class), e.message
+        end
       end
 
       private

--- a/lib/dentaku/ast/functions/avg.rb
+++ b/lib/dentaku/ast/functions/avg.rb
@@ -1,13 +1,13 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:avg, :numeric, ->(*args) {
-  if args.empty?
+  flatten_args = args.flatten
+  if flatten_args.empty?
     raise Dentaku::ArgumentError.for(
         :too_few_arguments,
         function_name: 'AVG()', at_least: 1, given: 0
     ), 'AVG() requires at least one argument'
   end
 
-  flatten_args = args.flatten
   flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+) / flatten_args.length
 })

--- a/lib/dentaku/ast/functions/mul.rb
+++ b/lib/dentaku/ast/functions/mul.rb
@@ -1,12 +1,13 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:mul, :numeric, ->(*args) {
-  if args.empty?
+  flatten_args = args.flatten
+  if flatten_args.empty?
     raise Dentaku::ArgumentError.for(
         :too_few_arguments,
         function_name: 'MUL()', at_least: 1, given: 0
     ), 'MUL() requires at least one argument'
   end
 
-  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(1, :*)
+  flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(1, :*)
 })

--- a/lib/dentaku/ast/functions/round.rb
+++ b/lib/dentaku/ast/functions/round.rb
@@ -1,5 +1,5 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:round, :numeric, lambda { |numeric, places = 0|
-  Dentaku::AST::Function.numeric(numeric).round(places.to_i)
+  Dentaku::AST::Function.numeric(numeric).round(Dentaku::AST::Function.numeric(places || 0).to_i)
 })

--- a/lib/dentaku/ast/functions/rounddown.rb
+++ b/lib/dentaku/ast/functions/rounddown.rb
@@ -1,7 +1,7 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:rounddown, :numeric, lambda { |numeric, precision = 0|
-  precision = precision.to_i
+  precision = Dentaku::AST::Function.numeric(precision || 0).to_i
   tens = 10.0**precision
   result = (Dentaku::AST::Function.numeric(numeric) * tens).floor / tens
   precision <= 0 ? result.to_i : result

--- a/lib/dentaku/ast/functions/roundup.rb
+++ b/lib/dentaku/ast/functions/roundup.rb
@@ -1,7 +1,7 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:roundup, :numeric, lambda { |numeric, precision = 0|
-  precision = precision.to_i
+  precision = Dentaku::AST::Function.numeric(precision || 0).to_i
   tens = 10.0**precision
   result = (Dentaku::AST::Function.numeric(numeric) * tens).ceil / tens
   precision <= 0 ? result.to_i : result

--- a/lib/dentaku/ast/functions/string_functions.rb
+++ b/lib/dentaku/ast/functions/string_functions.rb
@@ -32,7 +32,7 @@ module Dentaku
 
         def value(context = {})
           string = @string.value(context).to_s
-          length = @length.value(context)
+          length = Dentaku::AST::Function.numeric(@length.value(context)).to_i
           negative_argument_failure('LEFT') if length < 0
           string[0, length]
         end
@@ -54,7 +54,7 @@ module Dentaku
 
         def value(context = {})
           string = @string.value(context).to_s
-          length = @length.value(context)
+          length = Dentaku::AST::Function.numeric(@length.value(context)).to_i
           negative_argument_failure('RIGHT') if length < 0
           string[length * -1, length] || string
         end
@@ -76,9 +76,9 @@ module Dentaku
 
         def value(context = {})
           string = @string.value(context).to_s
-          offset = @offset.value(context)
+          offset = Dentaku::AST::Function.numeric(@offset.value(context)).to_i
           negative_argument_failure('MID', 'offset') if offset < 0
-          length = @length.value(context)
+          length = Dentaku::AST::Function.numeric(@length.value(context)).to_i
           negative_argument_failure('MID') if length < 0
           string[offset - 1, length].to_s
         end

--- a/lib/dentaku/ast/functions/sum.rb
+++ b/lib/dentaku/ast/functions/sum.rb
@@ -1,12 +1,13 @@
 require_relative '../function'
 
 Dentaku::AST::Function.register(:sum, :numeric, ->(*args) {
-  if args.empty?
+  flatten_args = args.flatten
+  if flatten_args.empty?
     raise Dentaku::ArgumentError.for(
         :too_few_arguments,
         function_name: 'SUM()', at_least: 1, given: 0
     ), 'SUM() requires at least one argument'
   end
 
-  args.flatten.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+)
+  flatten_args.map { |arg| Dentaku::AST::Function.numeric(arg) }.reduce(0, :+)
 })

--- a/spec/ast/arithmetic_spec.rb
+++ b/spec/ast/arithmetic_spec.rb
@@ -4,11 +4,12 @@ require 'dentaku/ast/arithmetic'
 require 'dentaku/token'
 
 describe Dentaku::AST::Arithmetic do
-  let(:one) { Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, 1) }
-  let(:two) { Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, 2) }
-  let(:x)   { Dentaku::AST::Identifier.new Dentaku::Token.new(:identifier, 'x') }
-  let(:y)   { Dentaku::AST::Identifier.new Dentaku::Token.new(:identifier, 'y') }
-  let(:ctx) { {'x' => 1, 'y' => 2} }
+  let(:one)  { Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, 1) }
+  let(:two)  { Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, 2) }
+  let(:x)    { Dentaku::AST::Identifier.new Dentaku::Token.new(:identifier, 'x') }
+  let(:y)    { Dentaku::AST::Identifier.new Dentaku::Token.new(:identifier, 'y') }
+  let(:ctx)  { {'x' => 1, 'y' => 2} }
+  let(:date) { Dentaku::AST::DateTime.new Dentaku::Token.new(:datetime, DateTime.new(2020, 4, 16)) }
 
   it 'performs an arithmetic operation with numeric operands' do
     expect(add(one, two)).to eq(3)
@@ -44,6 +45,19 @@ describe Dentaku::AST::Arithmetic do
     expect(add(x, one, 'x' => '.1')).to eq(1.1)
     expect { add(x, one, 'x' => 'invalid') }.to raise_error(Dentaku::ArgumentError)
     expect { add(x, one, 'x' => '') }.to raise_error(Dentaku::ArgumentError)
+  end
+
+  it 'performs arithmetic on arrays' do
+    expect(add(x, y, 'x' => [1], 'y' => [2])).to eq([1, 2])
+  end
+
+  it 'performs date arithmetic' do
+    expect(add(date, one)).to eq(DateTime.new(2020, 4, 17))
+  end
+
+  it 'raises ArgumentError if given individually valid but incompatible arguments' do
+    expect { add(one, date) }.to raise_error(Dentaku::ArgumentError)
+    expect { add(x, one, 'x' => [1]) }.to raise_error(Dentaku::ArgumentError)
   end
 
   private

--- a/spec/ast/avg_spec.rb
+++ b/spec/ast/avg_spec.rb
@@ -29,5 +29,9 @@ describe 'Dentaku::AST::Function::Avg' do
     it 'raises an error if no arguments are passed' do
       expect { calculator.evaluate!('AVG()') }.to raise_error(Dentaku::ArgumentError)
     end
+
+    it 'raises an error if an empty array is passed' do
+      expect { calculator.evaluate!('AVG(x)', x: []) }.to raise_error(Dentaku::ArgumentError)
+    end
   end
 end

--- a/spec/ast/mul_spec.rb
+++ b/spec/ast/mul_spec.rb
@@ -34,5 +34,9 @@ describe 'Dentaku::AST::Function::Mul' do
     it 'raises an error if no arguments are passed' do
       expect { calculator.evaluate!('MUL()') }.to raise_error(Dentaku::ArgumentError)
     end
+
+    it 'raises an error if an empty array is passed' do
+      expect { calculator.evaluate!('MUL(x)', x: []) }.to raise_error(Dentaku::ArgumentError)
+    end
   end
 end

--- a/spec/ast/negation_spec.rb
+++ b/spec/ast/negation_spec.rb
@@ -4,8 +4,9 @@ require 'dentaku/ast/arithmetic'
 require 'dentaku/token'
 
 describe Dentaku::AST::Negation do
-  let(:five) { Dentaku::AST::Logical.new Dentaku::Token.new(:numeric, 5) }
-  let(:t)    { Dentaku::AST::Numeric.new Dentaku::Token.new(:logical, true) }
+  let(:five) { Dentaku::AST::Numeric.new Dentaku::Token.new(:numeric, 5) }
+  let(:t)    { Dentaku::AST::Logical.new Dentaku::Token.new(:logical, true) }
+  let(:x)    { Dentaku::AST::Identifier.new Dentaku::Token.new(:identifier, 'x') }
 
   it 'allows access to its sub-node' do
     node = described_class.new(five)
@@ -28,5 +29,20 @@ describe Dentaku::AST::Negation do
     expect {
       described_class.new(group)
     }.not_to raise_error
+  end
+
+  it 'correctly parses string operands to numeric values' do
+    node = described_class.new(x)
+    expect(node.value('x' => '5')).to eq(-5)
+  end
+
+  it 'raises error if input string is not coercible to numeric' do
+    node = described_class.new(x)
+    expect { node.value('x' => 'invalid') }.to raise_error(Dentaku::ArgumentError)
+  end
+
+  it 'raises error if given a non-numeric argument' do
+    node = described_class.new(x)
+    expect { node.value('x' => true) }.to raise_error(Dentaku::ArgumentError)
   end
 end

--- a/spec/ast/round_spec.rb
+++ b/spec/ast/round_spec.rb
@@ -22,4 +22,14 @@ describe 'Dentaku::AST::Function::Round' do
     result = Dentaku('ROUND(x, y)', x: '1.8453', y: nil)
     expect(result).to eq(2)
   end
+
+  context 'checking errors' do
+    it 'raises an error if first argument is not numeric' do
+      expect { Dentaku!("ROUND(2020-1-1, 0)") }.to raise_error(Dentaku::ArgumentError)
+    end
+
+    it 'raises an error if places is not numeric' do
+      expect { Dentaku!("ROUND(1.8, 2020-1-1)") }.to raise_error(Dentaku::ArgumentError)
+    end
+  end
 end

--- a/spec/ast/rounddown_spec.rb
+++ b/spec/ast/rounddown_spec.rb
@@ -22,4 +22,14 @@ describe 'Dentaku::AST::Function::Round' do
     result = Dentaku('ROUNDDOWN(x, y)', x: '1.8453', y: nil)
     expect(result).to eq(1)
   end
+
+  context 'checking errors' do
+    it 'raises an error if first argument is not numeric' do
+      expect { Dentaku!("ROUND(2020-1-1, 0)") }.to raise_error(Dentaku::ArgumentError)
+    end
+
+    it 'raises an error if places is not numeric' do
+      expect { Dentaku!("ROUND(1.8, 2020-1-1)") }.to raise_error(Dentaku::ArgumentError)
+    end
+  end
 end

--- a/spec/ast/roundup_spec.rb
+++ b/spec/ast/roundup_spec.rb
@@ -22,4 +22,14 @@ describe 'Dentaku::AST::Function::Round' do
     result = Dentaku('ROUNDUP(x, y)', x: '1.8453', y: nil)
     expect(result).to eq(2)
   end
+
+  context 'checking errors' do
+    it 'raises an error if first argument is not numeric' do
+      expect { Dentaku!("ROUND(2020-1-1, 0)") }.to raise_error(Dentaku::ArgumentError)
+    end
+
+    it 'raises an error if places is not numeric' do
+      expect { Dentaku!("ROUND(1.8, 2020-1-1)") }.to raise_error(Dentaku::ArgumentError)
+    end
+  end
 end

--- a/spec/ast/string_functions_spec.rb
+++ b/spec/ast/string_functions_spec.rb
@@ -26,6 +26,10 @@ describe Dentaku::AST::StringFunctions::Left do
     expect(subject.value('string' => 'abcdefg', 'length' => 40)).to eq 'abcdefg'
   end
 
+  it 'accepts strings as length if they can be parsed to a number' do
+    expect(subject.value('string' => 'ABCDEFG', 'length' => '4')).to eq 'ABCD'
+  end
+
   it 'has the proper type' do
     expect(subject.type).to eq(:string)
   end
@@ -34,6 +38,12 @@ describe Dentaku::AST::StringFunctions::Left do
     expect {
       subject.value('string' => 'abcdefg', 'length' => -2)
     }.to raise_error(Dentaku::ArgumentError, /LEFT\(\) requires length to be positive/)
+  end
+
+  it 'raises an error when given a junk length' do
+    expect {
+      subject.value('string' => 'abcdefg', 'length' => 'junk')
+    }.to raise_error(Dentaku::ArgumentError, "'junk' is not coercible to numeric")
   end
 end
 
@@ -53,8 +63,18 @@ describe Dentaku::AST::StringFunctions::Right do
     expect(subject.value).to eq 'abcdefg'
   end
 
+  it 'accepts strings as length if they can be parsed to a number' do
+    subject = described_class.new(literal('ABCDEFG'), literal('4'))
+    expect(subject.value).to eq 'DEFG'
+  end
+
   it 'has the proper type' do
     expect(subject.type).to eq(:string)
+  end
+
+  it 'raises an error when given a junk length' do
+    subject = described_class.new(literal('abcdefg'), literal('junk'))
+    expect { subject.value }.to raise_error(Dentaku::ArgumentError, "'junk' is not coercible to numeric")
   end
 end
 
@@ -79,8 +99,23 @@ describe Dentaku::AST::StringFunctions::Mid do
     expect(subject.value).to eq 'defg'
   end
 
+  it 'accepts strings as offset and length if they can be parsed to a number' do
+    subject = described_class.new(literal('ABCDEFG'), literal('4'), literal('2'))
+    expect(subject.value).to eq 'DE'
+  end
+
   it 'has the proper type' do
     expect(subject.type).to eq(:string)
+  end
+
+  it 'raises an error when given a junk offset' do
+    subject = described_class.new(literal('abcdefg'), literal('junk offset'), literal(2))
+    expect { subject.value }.to raise_error(Dentaku::ArgumentError, "'junk offset' is not coercible to numeric")
+  end
+
+  it 'raises an error when given a junk length' do
+    subject = described_class.new(literal('abcdefg'), literal(4), literal('junk'))
+    expect { subject.value }.to raise_error(Dentaku::ArgumentError, "'junk' is not coercible to numeric")
   end
 end
 

--- a/spec/ast/sum_spec.rb
+++ b/spec/ast/sum_spec.rb
@@ -34,5 +34,9 @@ describe 'Dentaku::AST::Function::Sum' do
     it 'raises an error if no arguments are passed' do
       expect { calculator.evaluate!('SUM()') }.to raise_error(Dentaku::ArgumentError)
     end
+
+    it 'raises an error if an empty array is passed' do
+      expect { calculator.evaluate!('SUM(x)', x: []) }.to raise_error(Dentaku::ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
They used to raise NoMethodError or TypeError or other generic errors.
Now most cases are handled and they should raise  proper Dentaku errors.
Now evaluate will not raise error in those cases and will just return
nil.